### PR TITLE
Fix/name resolution except

### DIFF
--- a/launch/email.launch
+++ b/launch/email.launch
@@ -5,11 +5,11 @@
 	<arg name="desired_freq" default="10.0" />
 
 	<!-- Load smtp configuration -->
-	<arg name="smtp_config_path" default="$(find robotnik_email)/config/rnavarro_rbwatcher_eu.yaml" />
+	<arg name="smtp_config_path" default="$(find robotnik_email)/config/smtp_config.yaml" />
 
 	<!-- start smtp manager node -->
 	<node pkg="robotnik_email" name="smtp_manager" type="smtp_manager_node.py" output="screen">
-		<rosparam command="load" file="$(find robotnik_email)/config/rnavarro_rbwatcher_eu.yaml" />
+		<rosparam command="load" file="$(arg smtp_config_path)" />
 		<param name="desired_freq" value="$(arg desired_freq)"/>
 	</node>
 

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>robotnik_email</name>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
   <description>The robotnik_email package, based on RComponent structure. Email server to send messages through ROS</description>
 
   <maintainer email="rvasquez@robotnik.es">Robert Vasquez Zavaleta</maintainer>

--- a/src/robotnik_email/smtp_manager.py
+++ b/src/robotnik_email/smtp_manager.py
@@ -209,12 +209,15 @@ class SMTPManager(RComponent):
         response.ret.success = False
         response.ret.code = -1
         ret = False
+        ret_connection = False
         ret_msg = ''
         ret_code = 0
         try_send = True
         send_with_attachments = True
 
-        if self.smtp_connection():
+        ret_connection, ret_msg = self.smtp_connection()
+
+        if ret_connection is True:
 
             while try_send and ret is False:
 
@@ -248,20 +251,22 @@ class SMTPManager(RComponent):
                 else:
                     try_send = False
                     response.ret.message = "The email can not be sent because it is malformed"
+
+            try:
+                self.smtp_disconnection()
+            except smtplib.SMTPException as e:
+                rospy.logerr(e)
+
+            # if (response.ret.success == True) or (response.ret.code == 0):
+            #    rospy.loginfo(response.ret.message)
+            if (response.ret.success is False) or (response.ret.code != 0):
+                self.logger.logerror(response.ret.message, self.logger_tag)
+
         else:
 
             response.ret.message = "Cannot connect to SMTP server " + \
-                str(self.smtp_server) + " with port " + str(self.smtp_port)
-
-        try:
-            self.smtp_disconnection()
-        except smtplib.SMTPException as e:
-            rospy.logerr(e)
-
-        # if (response.ret.success == True) or (response.ret.code == 0):
-        #    rospy.loginfo(response.ret.message)
-        if (response.ret.success is False) or (response.ret.code != 0):
-            self.logger.logerror(response.ret.message, self.logger_tag)
+                str(self.smtp_server) + " with port " + \
+                str(self.smtp_port) + ": " + ret_msg
 
         return response
 
@@ -270,9 +275,12 @@ class SMTPManager(RComponent):
         Establishes a connection to the SMTP server.
 
         Returns:
-            bool: True if the connection is successfully established, False otherwise.
+            A tuple containing:
+                - bool: True if the connection is successfully established, False otherwise.
+                - str: A message indicating the result of the connection attempt.
         """
 
+        ret_msg = 'OK'
         try:
             if self.ssl:
                 rospy.loginfo(
@@ -301,9 +309,15 @@ class SMTPManager(RComponent):
         except smtplib.SMTPException as e:
             self.logger.logerror(
                 f"smtp_connection -> Exception: {e}", self.logger_tag)
+            ret_msg = f"{e}"
+            success = False
+        except Exception as e:
+            self.logger.logerror(
+                f"smtp_connection -> Exception: {e}", self.logger_tag)
+            ret_msg = f"{e}"
             success = False
 
-        return success
+        return success, ret_msg
 
     def build_email(self, email_data, send_with_attachments=True):
         """


### PR DESCRIPTION
This PR aims to fix a problem when name resolution of the server fails.
It made the node crash and no output feedback was returned

Now it has to return the following:

**Service Response**

![Screenshot from 2024-09-13 10-07-33](https://github.com/user-attachments/assets/b102a692-5cb7-42d0-886f-280f8d2a66a2)

**Terminal log**

![Screenshot from 2024-09-13 10-07-02](https://github.com/user-attachments/assets/668d6348-b2f0-476c-9052-9a3165f8b319)
